### PR TITLE
Fixed issue with data folder missing

### DIFF
--- a/src/update.js
+++ b/src/update.js
@@ -1,3 +1,10 @@
 const updaters = require('./updaters.js');
+var fs = require('fs');
+var path = require('path')
+var dir = path.join(__dirname, '../data')
+
+if (!fs.existsSync(dir)){
+    fs.mkdirSync(dir);
+}
 
 updaters.run();


### PR DESCRIPTION
On initial clone there isn't a data folder so `npm run update` throws an error. This code will automatically create the directory if it doesn't exist. 