### PR TITLE
Fixing issue with using curl from graphql playground w/o query_variables

### DIFF
--- a/src/utils/apolloLogger.js
+++ b/src/utils/apolloLogger.js
@@ -22,7 +22,7 @@ module.exports = {
     const ctx = _.omit(requestContext.context, '_extensionStack');
 
     const query = truncate(prettier.format(requestContext.request.query, { parser: 'graphql' }));
-    const vars = truncate(JSON.stringify(requestContext.request.variables, null, 2));
+    const vars = truncate(JSON.stringify(requestContext.request.variables || {}, null, 2));
     config.logger.debug(ctx, `GraphQL request started:\n${query}\nvariables:\n${vars}`);
 
     return {


### PR DESCRIPTION
This corrects an issue where if you don't use query variable the service will error. 