### PR TITLE
chore: refactor Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,16 @@ FROM node:14.15.0-alpine3.12 as build
 
 WORKDIR /usr/src/app
 COPY package*.json ./
-RUN npm install --production
-RUN cp -R node_modules prod_node_modules
-RUN npm install
+RUN npm install --production \
+  && cp -R node_modules prod_node_modules \
+  && npm install
 COPY . .
 RUN npm run build
 
 FROM node:14.15.0-alpine3.12 as release
 
 WORKDIR /usr/src/app
+RUN mkdir data
 COPY --from=build /usr/src/app/prod_node_modules ./node_modules
 COPY --from=build /usr/src/app/dist ./dist
 COPY package*.json ./


### PR DESCRIPTION
# Quick description

* group RUN commands
* add data directory at release step for pricing update jobs

# Why

Pricing update jobs silently fails because of missing data directory at container root

```
docker run -it infracost-pricing-api:test npm run update -- --only=aws:bulk                                                   

> cloud-pricing-api@1.0.0 update /usr/src/app
> node dist/cmd/update.js "--only=aws:bulk"

[1614350990587] INFO  (20 on 026dc857f7e8): Running update function for aws:bulk
[1614350990780] INFO  (20 on 026dc857f7e8): Downloading /offers/v1.0/aws/comprehend/current/index.json
```