### PR TITLE
Add DigitalOcean pricing

### DIFF
--- a/examples/queries/digitalocean/apps-professional-ams3.graphql
+++ b/examples/queries/digitalocean/apps-professional-ams3.graphql
@@ -1,0 +1,38 @@
+# Get the price for a professional tier Apps instance in the Amsterdam DC
+
+query {
+  products(
+    filter: {
+      vendorName: "digitalocean"
+      service: "Apps"
+      productFamily: "professional"
+      region: "ams3"
+      attributeFilters: [
+        { key: "cpuType", value: "SHARED" }
+        { key: "cpus", value: "1" }
+        { key: "memory", value: "1024" }
+      ]
+    }
+  ) {
+    prices(
+      filter: {
+        unit: "monthly"
+      }
+    ) { USD }
+  }
+}
+
+# Response
+#{
+#  "data": {
+#    "products": [
+#      {
+#        "prices": [
+#          {
+#            "USD": "12"
+#          }
+#        ]
+#      }
+#    ]
+#  }
+#}

--- a/examples/queries/digitalocean/droplets-basic-sfo1.graphql
+++ b/examples/queries/digitalocean/droplets-basic-sfo1.graphql
@@ -1,0 +1,36 @@
+# Get the price for a basic droplet in the San Francisco 1 DC
+
+query {
+  products(
+    filter: {
+      vendorName: "digitalocean"
+      service: "Droplets"
+      productFamily: "Basic"
+      region: "sfo1"
+      attributeFilters: [
+        { key: "memory", value: "1024" }
+      ]
+    }
+  ) {
+    prices(
+      filter: {
+        unit: "monthly"
+      }
+    ) { USD }
+  }
+}
+
+# Response
+#{
+#  "data": {
+#    "products": [
+#      {
+#        "prices": [
+#          {
+#            "USD": "5"
+#          }
+#        ]
+#      }
+#    ]
+#  }
+#}

--- a/src/cmd/dataScrape.ts
+++ b/src/cmd/dataScrape.ts
@@ -4,6 +4,7 @@ import awsBulk from '../scrapers/awsBulk';
 import awsSpot from '../scrapers/awsSpot';
 import azureRetail from '../scrapers/azureRetail';
 import digitaloceanApps from '../scrapers/digitaloceanApps';
+import digitaloceanDroplets from '../scrapers/digitaloceanDroplets';
 import gcpCatalog from '../scrapers/gcpCatalog';
 import gcpMachineTypes from '../scrapers/gcpMachineTypes';
 import { setPriceUpdateFailed, setPriceUpdateSuccessful } from '../stats/stats';
@@ -24,6 +25,7 @@ const Scrapers = {
   },
   digitalocean: {
     apps: digitaloceanApps.scrape,
+    droplets: digitaloceanDroplets.scrape,
   },
   gcp: {
     catalog: gcpCatalog.scrape,
@@ -34,7 +36,7 @@ const Scrapers = {
 async function run(): Promise<void> {
   const { argv } = yargs
     .usage(
-      'Usage: $0 --only=[aws:bulk,aws:spot,azure:retail,digitalocean:apps,gcp:catalog,gcp:machineTypes]'
+      'Usage: $0 --only=[aws:bulk,aws:spot,azure:retail,digitalocean:apps,digitalocean:droplets,gcp:catalog,gcp:machineTypes]'
     )
     .options({
       only: { type: 'string' },

--- a/src/cmd/dataScrape.ts
+++ b/src/cmd/dataScrape.ts
@@ -3,6 +3,7 @@ import config from '../config';
 import awsBulk from '../scrapers/awsBulk';
 import awsSpot from '../scrapers/awsSpot';
 import azureRetail from '../scrapers/azureRetail';
+import digitaloceanApps from '../scrapers/digitaloceanApps';
 import gcpCatalog from '../scrapers/gcpCatalog';
 import gcpMachineTypes from '../scrapers/gcpMachineTypes';
 import { setPriceUpdateFailed, setPriceUpdateSuccessful } from '../stats/stats';
@@ -21,6 +22,9 @@ const Scrapers = {
   azure: {
     retail: azureRetail.scrape,
   },
+  digitalocean: {
+    apps: digitaloceanApps.scrape,
+  },
   gcp: {
     catalog: gcpCatalog.scrape,
     machineTypes: gcpMachineTypes.scrape,
@@ -30,7 +34,7 @@ const Scrapers = {
 async function run(): Promise<void> {
   const { argv } = yargs
     .usage(
-      'Usage: $0 --only=[aws:bulk,aws:spot,azure:retail,gcp:catalog,gcp:machineTypes]'
+      'Usage: $0 --only=[aws:bulk,aws:spot,azure:retail,digitalocean:apps,gcp:catalog,gcp:machineTypes]'
     )
     .options({
       only: { type: 'string' },

--- a/src/config.ts
+++ b/src/config.ts
@@ -86,6 +86,7 @@ const config = {
   gcpApiKey: process.env.GCP_API_KEY,
   gcpKeyFile: generateGcpKeyFile(),
   gcpProject: process.env.GCP_PROJECT,
+  digitalOceanToken: process.env.DIGITALOCEAN_TOKEN,
 };
 
 export default config;

--- a/src/scrapers/digitaloceanApps.ts
+++ b/src/scrapers/digitaloceanApps.ts
@@ -1,0 +1,127 @@
+import axios from "axios";
+import fs from "fs";
+import config from "../config";
+import { Product, Price } from '../db/types';
+import { generateProductHash, generatePriceHash } from '../db/helpers';
+import { upsertProducts } from '../db/upsert';
+
+const baseUrl = 'https://api.digitalocean.com/v2';
+
+type InstanceResponse = {
+  // eslint-disable-next-line camelcase
+  instance_sizes: Array<Instance>
+}
+
+type Instance = {
+  name: string,
+  slug: string
+  // eslint-disable-next-line camelcase
+  tier_slug: string,
+  // eslint-disable-next-line camelcase
+  usd_per_month: string,
+  // eslint-disable-next-line camelcase
+  usd_per_second: string,
+  // eslint-disable-next-line camelcase
+  memory_bytes: string,
+  cpus: string
+  // eslint-disable-next-line camelcase
+  cpu_type: string,
+}
+
+type RegionsResponse = {
+  regions: Array<Region>
+}
+
+type Region = {
+  // eslint-disable-next-line camelcase
+  data_centers: Array<string>
+}
+
+async function downloadJson(path: string) {
+  const url = `${baseUrl}${path}`;
+  const segments = path.split('/');
+  const data = segments[segments.length - 1];
+
+  config.logger.info(`Downloading ${url}`);
+
+  const response = await axios({
+    method: 'get',
+    url,
+    responseType: 'stream',
+    headers: {
+      Authorization: `Bearer ${config.digitalOceanToken}`,
+    },
+  });
+  const writer = fs.createWriteStream(`data/digitalocean-apps-${data}.json`);
+  response.data.pipe(writer);
+  await new Promise(resolve => writer.on('finish', resolve));
+}
+
+function generateProduct(instance: Instance): Product {
+  return {
+    productHash: '',
+    vendorName: 'digitalocean',
+    service: 'Apps',
+    productFamily: instance.tier_slug,
+    region: '',
+    sku: instance.slug,
+    attributes: {
+      cpus: instance.cpus,
+      cpuType: instance.cpu_type,
+      memory: (parseInt(instance.memory_bytes, 10) / 1024 / 1024).toString(),
+    },
+    prices: [],
+  };
+}
+
+function generatePrice(unit: 'hourly' | 'monthly', instance: Instance, product: Product): Price {
+  const cost = unit === 'hourly' ? parseFloat(instance.usd_per_second) * 60 * 60 : parseFloat(instance.usd_per_month);
+  const price = {
+    priceHash: '',
+    unit,
+    USD: cost.toString(),
+    purchaseOption: '',
+    effectiveDateStart: '',
+  };
+  price.priceHash = generatePriceHash(product, price);
+  return price;
+}
+
+async function processApps() {
+  const regionsContent = fs.readFileSync('data/digitalocean-apps-regions.json');
+  const { regions: regionGroups } = <RegionsResponse>JSON.parse(regionsContent.toString());
+  const regions = regionGroups.flatMap(group => group.data_centers);
+  config.logger.info(`Got ${regions.length} regions in ${regionGroups.length} groups`);
+
+  const instancesContent = fs.readFileSync('data/digitalocean-apps-instance_sizes.json');
+  const { instance_sizes: instances } = <InstanceResponse>JSON.parse(instancesContent.toString());
+  config.logger.info(`Got ${instances.length} instance types`);
+
+  const products = instances.flatMap(instance => {
+    return regions.map(region => {
+      const product = generateProduct(instance);
+
+      product.region = region;
+      product.productHash = generateProductHash(product);
+      product.prices = [
+        generatePrice('hourly', instance, product),
+        generatePrice('monthly', instance, product),
+      ];
+
+      return product;
+    });
+  });
+
+  config.logger.info(`Added ${products.length} products`);
+  await upsertProducts(products);
+}
+
+async function scrape(): Promise<void> {
+  await downloadJson('/apps/regions');
+  await downloadJson('/apps/tiers/instance_sizes');
+  await processApps();
+}
+
+export default {
+  scrape,
+};

--- a/src/scrapers/digitaloceanDroplets.ts
+++ b/src/scrapers/digitaloceanDroplets.ts
@@ -1,0 +1,109 @@
+import axios from 'axios';
+import fs from 'fs';
+import config from '../config';
+import { generateProductHash, generatePriceHash } from '../db/helpers';
+import { Product, Price } from '../db/types';
+import { upsertProducts } from '../db/upsert';
+
+const url = 'https://api.digitalocean.com/v2/sizes';
+
+type Response = {
+  sizes: Array<Droplet>,
+};
+
+type Droplet = {
+  slug: string,
+  transfer: number,
+  memory: number,
+  vcpus: number,
+  disk: number,
+  // eslint-disable-next-line camelcase
+  price_monthly: number,
+  // eslint-disable-next-line camelcase
+  price_hourly: number,
+  regions: Array<string>,
+  available: boolean,
+  description: string,
+};
+
+async function downloadJson() {
+  config.logger.info(`Downloading ${url}`);
+  const response = await axios({
+    method: 'get',
+    url,
+    responseType: 'stream',
+    headers: {
+      Authorization: `Bearer ${config.digitalOceanToken}`,
+    },
+    params: {
+      // eslint-disable-next-line camelcase
+      per_page: 250
+    }
+  });
+  const writer = fs.createWriteStream('data/digitalocean-droplets.json');
+  response.data.pipe(writer);
+  await new Promise(resolve => writer.on('finish', resolve));
+}
+
+function generateProduct(droplet: Droplet): Product {
+  return {
+    productHash: '',
+    vendorName: 'digitalocean',
+    service: 'Droplets',
+    productFamily: droplet.description,
+    region: '',
+    sku: droplet.slug,
+    attributes: {
+      transfer: droplet.transfer.toString(),
+      vcpus: droplet.vcpus.toString(),
+      memory: droplet.memory.toString(),
+      disk: droplet.disk.toString(),
+    },
+    prices: [],
+  };
+}
+
+function generatePrice(unit: 'hourly' | 'monthly', droplet: Droplet, product: Product): Price {
+  const cost = unit === 'hourly' ? droplet.price_hourly : droplet.price_monthly;
+  const price = {
+    priceHash: '',
+    unit,
+    USD: cost.toString(),
+    purchaseOption: '',
+    effectiveDateStart: '',
+  };
+  price.priceHash = generatePriceHash(product, price);
+  return price;
+}
+
+async function processDroplets() {
+  const body = fs.readFileSync('data/digitalocean-droplets.json');
+  const json = <Response>JSON.parse(body.toString());
+
+  const products = json.sizes.flatMap(droplet => {
+    return droplet.regions.map(region => {
+      const product = generateProduct(droplet);
+
+      product.region = region;
+      product.productHash = generateProductHash(product);
+      product.prices = [
+        generatePrice('hourly', droplet, product),
+        generatePrice('monthly', droplet, product),
+      ];
+
+      return product;
+    });
+  });
+
+  config.logger.info(`Added ${products.length} products`);
+  await upsertProducts(products);
+}
+
+async function scrape(): Promise<void> {
+  await downloadJson();
+  await processDroplets();
+}
+
+export default {
+  scrape,
+};

--- a/src/scrapers/run.ts
+++ b/src/scrapers/run.ts
@@ -4,6 +4,7 @@ import awsBulk from './awsBulk';
 import awsSpot from './awsSpot';
 import azureRetail from './azureRetail';
 import digitaloceanApps from './digitaloceanApps';
+import digitaloceanDroplets from './digitaloceanDroplets';
 import gcpCatalog from './gcpCatalog';
 import gcpMachineTypes from './gcpMachineTypes';
 
@@ -23,6 +24,7 @@ const Scrapers = {
   },
   digitalocean: {
     apps: digitaloceanApps.scrape,
+    droplets: digitaloceanDroplets.scrape,
   },
   gcp: {
     catalog: gcpCatalog.scrape,
@@ -33,7 +35,7 @@ const Scrapers = {
 async function run(): Promise<void> {
   const { argv } = yargs
     .usage(
-      'Usage: $0 --only=[aws:bulk,aws:spot,azure:retail,digitalocean:apps,gcp:catalog,gcp:machineTypes]'
+      'Usage: $0 --only=[aws:bulk,aws:spot,azure:retail,digitalocean:apps,digitalocean:droplets,gcp:catalog,gcp:machineTypes]'
     )
     .options({
       only: { type: 'string' },

--- a/src/scrapers/run.ts
+++ b/src/scrapers/run.ts
@@ -3,6 +3,7 @@ import config from '../config';
 import awsBulk from './awsBulk';
 import awsSpot from './awsSpot';
 import azureRetail from './azureRetail';
+import digitaloceanApps from './digitaloceanApps';
 import gcpCatalog from './gcpCatalog';
 import gcpMachineTypes from './gcpMachineTypes';
 
@@ -20,6 +21,9 @@ const Scrapers = {
   azure: {
     retail: azureRetail.scrape,
   },
+  digitalocean: {
+    apps: digitaloceanApps.scrape,
+  },
   gcp: {
     catalog: gcpCatalog.scrape,
     machineTypes: gcpMachineTypes.scrape,
@@ -29,7 +33,7 @@ const Scrapers = {
 async function run(): Promise<void> {
   const { argv } = yargs
     .usage(
-      'Usage: $0 --only=[aws:bulk,aws:spot,azure:retail,gcp:catalog,gcp:machineTypes]'
+      'Usage: $0 --only=[aws:bulk,aws:spot,azure:retail,digitalocean:apps,gcp:catalog,gcp:machineTypes]'
     )
     .options({
       only: { type: 'string' },


### PR DESCRIPTION
resolves infracost/infracost#808

Adds pricing information for DigitalOcean pulled from their official API. 


Currently supported resources:
- [x] Apps
- [ ] Block Storage
- [ ] Container Registry
- [x] Droplets
- [ ] Floating IPs
- [ ] Load Balancers
- [ ] Managed Databases

Unfortunately, it seems like Apps and Droplets are the only resources with a dedicated pricing endpoint. There are ways to get the pricing information by using internal DigitalOcean APIs, but it would be incredibly hacky. The two hacky options I see are:
- using the undocumented control panel APIs, but they require a session token stored in a cookie
- using the [pricing page JSON source](https://www.digitalocean.com/page-data/pricing/page-data.json), but there isn't much information other than pricing