### PR TITLE
fix: type errors in logger causing 500 errors

### DIFF
--- a/src/utils/apolloLogger.ts
+++ b/src/utils/apolloLogger.ts
@@ -11,6 +11,10 @@ import { Logger } from 'pino';
 const DEFAULT_TRUNCATE_LENGTH = 4096;
 
 function truncate(str: string, l = DEFAULT_TRUNCATE_LENGTH): string {
+  if (str == null) {
+    return ""
+  }
+
   if (str.length <= l) {
     return str;
   }
@@ -30,9 +34,15 @@ export default class ApolloLogger implements ApolloServerPlugin {
       return {};
     }
 
-    const query = truncate(
-      prettier.format(requestContext.request.query || '', { parser: 'graphql' })
-    );
+    let q = "";
+    try {
+      q = prettier.format(requestContext.request.query || '', { parser: 'graphql' })
+    } catch (e) {
+      const el = truncate(requestContext.request.query || '')
+      logger.debug(`invalid query provided: ${el}`)
+    }
+
+    const query = truncate(q);
     const vars = truncate(
       JSON.stringify(requestContext.request.variables || {}, null, 2)
     );


### PR DESCRIPTION
This PR fixes bug where `500` status codes were returned if an empty or invalid graphql query was given.

The apollo server returns `400` in both of these cases by default, see: https://github.com/apollographql/apollo-server/blob/main/packages/apollo-server-core/src/__tests__/runHttpQuery.test.ts

However, Infracosts `apolloLogger` which decorates logging output were causing the 500s because:

1. With an empty body the `truncate` method receives `undefined` as a `str` var. The `.length` prop call throws a 500 error
2. With an invalid body the `prettier.format` threw an exception which wasn't caught