### PR TITLE
feat: add a PATH_PREFIX env variable

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -64,6 +64,15 @@ const logger = pino({
 
 const cache = new NodeCache();
 
+let pathPrefix = process.env.PATH_PREFIX || '/';
+if (!pathPrefix.startsWith('/')) {
+  pathPrefix = `/${pathPrefix}`;
+}
+
+if (!pathPrefix.endsWith('/')) {
+  pathPrefix = `${pathPrefix}/`;
+}
+
 const config = {
   logger,
   pg,
@@ -82,6 +91,7 @@ const config = {
   infracostAPIKey: process.env.INFRACOST_API_KEY,
   selfHostedInfracostAPIKey: process.env.SELF_HOSTED_INFRACOST_API_KEY,
   cache,
+  pathPrefix,
   port: Number(process.env.PORT) || 4000,
   gcpApiKey: process.env.GCP_API_KEY,
   gcpKeyFile: generateGcpKeyFile(),

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,8 @@ import config from './config';
 
 createApp().then((app) => {
   app.listen(config.port, '0.0.0.0', () => {
-    config.logger.info(`🚀  Server ready at http://0.0.0.0:${config.port}/`);
+    config.logger.info(
+      `🚀  Server ready at http://0.0.0.0:${config.port}${config.pathPrefix}`
+    );
   });
 });


### PR DESCRIPTION
This can be used if the Cloud Pricing API is running under a sub-path, e.g. if you're using ALB and not rewriting the paths with nginx.