### PR TITLE
fix: GCP spot instance showing incorrect prices

### DIFF
--- a/src/scrapers/gcpMachineTypes.ts
+++ b/src/scrapers/gcpMachineTypes.ts
@@ -190,7 +190,7 @@ async function calculateAmountFromTotal(
 
   let descRegex = new RegExp(`^${desc}`);
   if (purchaseOption === 'preemptible') {
-    descRegex = new RegExp(`^Preemptible ${desc}`);
+    descRegex = new RegExp(`^Spot Preemptible ${desc}`);
   }
 
   const matchedProduct = await findComputeProducts(product.region, descRegex);
@@ -226,8 +226,8 @@ async function calculateAmountFromCpuAndMem(
   let cpuDescRegex = new RegExp(`^${cpuDesc}`);
   let memDescRegex = new RegExp(`^${memDesc}`);
   if (purchaseOption === 'preemptible') {
-    cpuDescRegex = new RegExp(`^Preemptible ${cpuDesc}`);
-    memDescRegex = new RegExp(`^Preemptible ${memDesc}`);
+    cpuDescRegex = new RegExp(`^Spot Preemptible ${cpuDesc}`);
+    memDescRegex = new RegExp(`^Spot Preemptible ${memDesc}`);
   }
 
   const cpuProduct = await findComputeProducts(product.region, cpuDescRegex);


### PR DESCRIPTION
fixes: https://github.com/infracost/cloud-pricing-api/issues/230

Updates GCP preemptible description regex to include a "Spot" prefix. GCP have changed their pricing descriptions
to include this prefix, e.g.:

```
"Spot Preemptible N2 Custom Extended Instance Ram running in Americas"
"Spot Preemptible N2 Custom Instance Core running in Americas"
"Spot Preemptible N2 Custom Instance Ram running in Americas"
```

This meant that the scraper was finding nil products when running an update. This is now resolved with this change.