### PR TITLE
Adding ca certificates to connection pool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ RUN npm run build
 
 FROM node:16.13-alpine3.12 as release
 
-RUN apk add --no-cache bash curl postgresql-client
+RUN apk add --no-cache bash ca-certificates curl postgresql-client && rm -rf /var/cache/apk/*
+RUN curl "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" --output /tmp/global-bundle.pem
+RUN cat /tmp/global-bundle.pem >> /etc/ssl/certs/ca-certificates.crt
 
 WORKDIR /usr/src/app
 RUN mkdir -p data/products

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,6 +30,10 @@ async function pg(): Promise<Pool> {
       port: Number(process.env.POSTGRES_PORT) || 5432,
       host: process.env.POSTGRES_HOST || 'localhost',
       max: Number(process.env.POSTGRES_MAX_CLIENTS) || 10,
+      ssl: {
+        rejectUnauthorized: true,
+        ca: fs.readFileSync('/etc/ssl/certs/ca-certificates.crt').toString(),
+      },
     };
 
     if (process.env.POSTGRES_URI) {


### PR DESCRIPTION
This configuration will support using RDS with SSL:
https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html
https://node-postgres.com/features/ssl

Addresses https://github.com/infracost/cloud-pricing-api/issues/433