### PR TITLE
Https proxy agent support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cloud-pricing-api",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cloud-pricing-api",
-      "version": "0.3.18",
+      "version": "0.3.19",
       "license": "Apache-2.0",
       "dependencies": {
         "@graphql-tools/schema": "^9.0.12",
@@ -23,6 +23,7 @@
         "glob": "^8.0.3",
         "googleapis": "^110.0.0",
         "graphql": "^16.6.0",
+        "https-proxy-agent": "^5.0.1",
         "lodash": "^4.17.21",
         "mingo": "^6.1.2",
         "node-cache": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "glob": "^8.0.3",
     "googleapis": "^110.0.0",
     "graphql": "^16.6.0",
+    "https-proxy-agent": "^5.0.1",
     "lodash": "^4.17.21",
     "mingo": "^6.1.2",
     "node-cache": "^5.1.2",

--- a/src/cmd/dataDownload.ts
+++ b/src/cmd/dataDownload.ts
@@ -78,6 +78,7 @@ async function run() {
 
   await new Promise((resolve, reject) => {
     fetch(downloadUrl, {
+      agent,
       method: 'get',
     }).then((resp) => {
       const progressBar = new ProgressBar(

--- a/src/cmd/dataDownload.ts
+++ b/src/cmd/dataDownload.ts
@@ -3,6 +3,7 @@ import ProgressBar from 'progress';
 import fs from 'fs';
 import yargs from 'yargs';
 import config from '../config';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 
 const proxy = process.env.HTTPS_PROXY || process.env.https_proxy;
 

--- a/src/cmd/dataDownload.ts
+++ b/src/cmd/dataDownload.ts
@@ -4,6 +4,10 @@ import fs from 'fs';
 import yargs from 'yargs';
 import config from '../config';
 
+const proxy = process.env.HTTPS_PROXY || process.env.https_proxy;
+
+const agent = proxy ? new HttpsProxyAgent(proxy) : undefined;
+
 async function run() {
   const argv = await yargs
     .usage(
@@ -27,6 +31,7 @@ async function run() {
     latestResp = await fetch(
       `${config.infracostPricingApiEndpoint}/data-download/latest`,
       {
+        agent, 
         headers: {
           'X-Api-Key': config.infracostAPIKey || '',
           'X-Cloud-Pricing-Api-Version': process.env.npm_package_version || '',


### PR DESCRIPTION
This change allows you to run the init_job from behind a proxy (i.e. squid).

These are my squid logs when running the built container with this change....
```
1699980257.290     94 10.0.10.20 TCP_TUNNEL/200 2194015 CONNECT registry.npmjs.org:443 - HIER_DIRECT/104.16.27.34 -
1699980259.140    469 10.0.10.20 TCP_TUNNEL/200 7606 CONNECT pricing.api.infracost.io:443 - HIER_DIRECT/3.135.51.119 -
1699980281.909  22757 10.0.10.20 TCP_TUNNEL/200 412352764 CONNECT pricing-api-db-data-settled-blowfish.s3.us-east-2.amazonaws.com:443 - HIER_DIRECT/52.219.92.242 -
```